### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 AsyncSenTest
 ============
 
-Asynchronous Tests for built in XCode OCTest
+Asynchronous Tests for built in Xcode OCTest


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
